### PR TITLE
Prove of concept to store the push notifications token

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,16 +2,36 @@ import React from 'react';
 import { StyleSheet, Text, View, WebView } from 'react-native';
 import { registerForPushNotificationsAsync } from './lib/pushNotifications';
 
+const loggedInUrlRegex = /members/;
+const mainUrl = 'https://www.timeoverflow.org/';
+
 export default class App extends React.Component {
-  componentDidMount() {
-    registerForPushNotificationsAsync();
+  componentDidMount() {}
+
+  registerForPushNotifications() {
+    const token = await registerForPushNotificationsAsync();
+
+    this.runRemoteTokenStoring(token);
+  }
+
+  onNavigationStateChange({ url }) {
+    if (loggedInUrlRegex.test(url)) {
+      this.registerForPushNotifications()
+    }
+  }
+
+  runRemoteTokenStoring(token) {
+    this.webview.injectJavaScript(`window.TimeOverflowRegisterExpoDeviceToken(\'${token}\');`);
   }
 
   render() {
     return (
       <WebView
-        source={{uri: 'https://www.timeoverflow.org/'}}
+        ref={ref => (this.webview = ref)}
+        source={{ uri: mainUrl }}
         style={{marginTop: 20}}
+        onNavigationStateChange={this.onNavigationStateChange.bind(this)}
+        scalesPageToFit={false}
       />
     );
   }

--- a/lib/pushNotifications.js
+++ b/lib/pushNotifications.js
@@ -3,9 +3,8 @@ import { Permissions, Notifications } from 'expo';
 const PUSH_ENDPOINT = 'https://your-server.com/users/push-token';
 
 export async function registerForPushNotificationsAsync() {
-  const { status: existingStatus } = await Permissions.getAsync(
-    Permissions.NOTIFICATIONS
-  );
+  const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
+
   let finalStatus = existingStatus;
 
   // only ask if permissions have not already been determined, because
@@ -18,29 +17,10 @@ export async function registerForPushNotificationsAsync() {
   }
 
   // Stop here if the user did not grant permissions
-  if (finalStatus !== 'granted') {
-    return;
-  }
+  if (finalStatus !== 'granted') return;
 
   // Get the token that uniquely identifies this device
   let token = await Notifications.getExpoPushTokenAsync();
 
-  console.log('user token', token);
-
-  // POST the token to your backend server from where you can retrieve it to send push notifications.
-  // return fetch(PUSH_ENDPOINT, {
-  //   method: 'POST',
-  //   headers: {
-  //     Accept: 'application/json',
-  //     'Content-Type': 'application/json',
-  //   },
-  //   body: JSON.stringify({
-  //     token: {
-  //       value: token,
-  //     },
-  //     user: {
-  //       username: 'Brent',
-  //     },
-  //   }),
-  // });
+  return token;
 }


### PR DESCRIPTION
Here there's a Proof of Concept of storing the Expo device token in our backend. For that, we execute the `TimeOverflowRegisterExpoDeviceToken` library in the WebView when the user is Logged In. For that we use the `injectJavascript` method which allows you to inject JS in the WebView.

Related:
https://github.com/coopdevs/timeoverflow/pull/329
https://github.com/coopdevs/timeoverflow/pull/329/files#diff-c1bb3091d6fc642a5ea8502be0ef07feR1