### PR TITLE
Upgrade negotiator to version 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "expo": "^24.0.0",
     "react": "16.0.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz",
+    "negotiator": ">=0.6.1"
   }
 }


### PR DESCRIPTION
This fixes the following vulnerability found in package-lock.json

CVE-2016-10539 More information
high severity
Vulnerable versions: < 0.6.1
Patched version: 0.6.1
negotiator is an HTTP content negotiator for Node.js and is used by many
modules and frameworks including Express and Koa. The header for
"Accept-Language", when parsed by negotiator 0.6.0 and earlier is
vulnerable to Regular Expression Denial of Service via a specially
crafted string.

This was reported by Github. See https://github.com/coopdevs/timeoverflow-mobile-app/network/alert/package-lock.json/negotiator/open