### PR TITLE
Upgrade fresh to 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "expo": "^24.0.0",
     "react": "16.0.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz"
+    "react-native": "https://github.com/expo/react-native/archive/sdk-24.0.0.tar.gz",
+    "fresh": ">=0.5.2"
   }
 }


### PR DESCRIPTION
This fixes the following vulnerability found in package-lock.json

CVE-2017-16119 More information
high severity
Vulnerable versions: < 0.5.2
Patched version: 0.5.2
Fresh is a module used by the Express.js framework for HTTP response
freshness testing. It is vulnerable to a regular expression denial of
service when it is passed specially crafted input to parse. This causes
the event loop to be blocked causing a denial of service condition.

This was reported by Github. See https://github.com/coopdevs/timeoverflow-mobile-app/network/alert/package-lock.json/fresh/open